### PR TITLE
(#22) Update actions to current versions.

### DIFF
--- a/.github/workflows/ocpl_cm_standards_check.yml
+++ b/.github/workflows/ocpl_cm_standards_check.yml
@@ -1,0 +1,9 @@
+name: OCPL Configuration Management Standards Check
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+jobs:
+  commitlint_remote:
+    uses: nciocpl/.github/.github/workflows/ocpl_cm_standards_check.yml@workflow/v2

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Get the code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up node
-        uses:  actions/setup-node@v3
+        uses:  actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -48,9 +48,9 @@ jobs:
           CI: true
 
       - name: Archive test artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
-          name: test-results
+          name: test-results-${{ matrix.operating-system }}
           path: coverage
 
 
@@ -73,10 +73,10 @@ jobs:
     steps:
 
       - name: Get the code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up node
-        uses:  actions/setup-node@v3
+        uses:  actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -152,7 +152,7 @@ jobs:
               exit 0
 
       - name: Upload Integration test results
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: integration-test-results
           path: integration-tests/target


### PR DESCRIPTION
- Give uploaded test results unique name per OS.
- Add CM standards check workflow.

Closes #22